### PR TITLE
Add Annotation command to the CLI

### DIFF
--- a/cmd/annotation.go
+++ b/cmd/annotation.go
@@ -136,9 +136,9 @@ func (d *DeisCmd) AnnotationUnset(appID string, appType string, annotations []st
 func parseAnnotations(annotations []string) (api.Annotation, error) {
 	annotationsMap := make(api.Annotation)
 
-	regex := regexp.MustCompile(`^([A-Za-z_]+.*)=([\s\S]*)$`)
+	regex := regexp.MustCompile(`^([A-Za-z_]+.*)=([\s\S]+)$`)
 	for _, annotation := range annotations {
-		if annotation[0] == '#' {
+		if len(annotation) > 0 && annotation[0] == '#' {
 			continue
 		}
 		if regex.MatchString(annotation) {

--- a/cmd/annotation.go
+++ b/cmd/annotation.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/deis/pkg/prettyprint"
+	"regexp"
+
+	"github.com/deis/controller-sdk-go/api"
+	"github.com/deis/controller-sdk-go/config"
+)
+
+// AnnotationList lists an app annotations
+func (d *DeisCmd) AnnotationList(appID string, format string) error {
+	settings, appID, err := load(d.ConfigFile, appID)
+
+	if err != nil {
+		return err
+	}
+
+	config, err := config.List(settings.Client, appID)
+	if d.checkAPICompatibility(settings.Client, err) != nil {
+		return err
+	}
+	var configOutput = new(bytes.Buffer)
+
+	/*** type casting to map[string]interface{}
+	 * the sortKeys function takes a map[string]interface{}, but config.Annotations
+	 * is of type map[string]Annotations. Because of that type difference, the function
+	 * cannot take `config.Annotation` directly. So we have two main options, either
+	 * replicate the sortKeys function changing only its type signature, or copy
+	 * the map into another one with the correct type. This approach was selected
+	 * because this map will likely have 2 or 3 elements, so copying this way
+	 * should not impact negatively on performance and will keep the code cleaner.
+	 */
+	interfacedStuff := make(map[string]interface{})
+	for k, v := range config.Annotations {
+		interfacedStuff[k] = v
+	}
+
+	sortedTypes := sortKeys(interfacedStuff)
+
+	for _, appType := range sortedTypes {
+		annotations := config.Annotations[appType]
+		keys := sortKeys(annotations)
+		switch format {
+		case "oneline":
+			fmt.Fprintf(configOutput, "%s:", appType)
+			for _, key := range keys {
+				value := annotations[key]
+				fmt.Fprintf(configOutput, " %s=%s", key, value)
+			}
+			fmt.Fprintf(configOutput, "\n")
+		case "diff":
+			fmt.Fprintf(configOutput, "%s:\n", appType)
+			for _, key := range keys {
+				value := annotations[key]
+				fmt.Fprintf(configOutput, "    %s=%s\n", key, value)
+			}
+		default:
+			fmt.Fprintf(configOutput, "=== %s Annotations\n", appType)
+			prettyPrintAnnotations := make(map[string]string)
+            for _, key := range keys {
+				value := annotations[key]
+				prettyPrintAnnotations[key] = value.(string)
+			}
+			fmt.Fprint(configOutput, prettyprint.PrettyTabs(prettyPrintAnnotations, 6))
+		}
+	}
+
+	d.Print(configOutput)
+	return nil
+}
+
+// AnnotationSet sets an app's annotations.
+func (d *DeisCmd) AnnotationSet(appID string, appType string, annotationCommandLine []string) error {
+	settings, appID, err := load(d.ConfigFile, appID)
+
+	if err != nil {
+		return err
+	}
+
+	annotations, err := parseAnnotations(annotationCommandLine)
+	if err != nil {
+		return err
+	}
+
+	d.Print("Creating Annotations... ")
+
+	quit := progress(d.WOut)
+
+	appAnnotations := make(map[string]api.Annotation)
+	appAnnotations[appType] = annotations
+	configObj := api.Config{Annotations: appAnnotations}
+	configObj, err = config.Set(settings.Client, appID, configObj)
+
+	quit <- true
+	<-quit
+	if d.checkAPICompatibility(settings.Client, err) != nil {
+		return err
+	}
+
+	d.Print("done\n\n")
+
+	return d.AnnotationList(appID, "")
+}
+
+// AnnotationUnset removes an annotation from an app.
+func (d *DeisCmd) AnnotationUnset(appID string, appType string, annotations []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
+
+	if err != nil {
+		return err
+	}
+
+	d.Print("Removing Annotations... ")
+
+	quit := progress(d.WOut)
+
+	configObj := api.Config{}
+
+	valuesMap := make(map[string]interface{})
+
+	for _, configVar := range annotations {
+		valuesMap[configVar] = nil
+	}
+
+	annotationMap := make(map[string]api.Annotation)
+	annotationMap[appType] = valuesMap
+	configObj.Annotations = annotationMap
+
+	_, err = config.Set(s.Client, appID, configObj)
+	quit <- true
+	<-quit
+	if d.checkAPICompatibility(s.Client, err) != nil {
+		return err
+	}
+
+	d.Print("done\n\n")
+
+	return d.AnnotationList(appID, "")
+}
+
+func parseAnnotations(annotations []string) (api.Annotation, error) {
+	annotationsMap := make(api.Annotation)
+
+	regex := regexp.MustCompile(`^([A-Za-z_]+.*)=([\s\S]*)$`)
+	for _, annotation := range annotations {
+		if annotation[0] == '#' {
+			continue
+		}
+		if regex.MatchString(annotation) {
+			captures := regex.FindStringSubmatch(annotation)
+			annotationsMap[captures[1]] = captures[2]
+		} else {
+			return nil, fmt.Errorf("'%s' does not match the pattern 'key=var', ex: MODE=test\n", annotation)
+		}
+	}
+
+	return annotationsMap, nil
+}

--- a/cmd/annotation.go
+++ b/cmd/annotation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/deis/pkg/prettyprint"
 	"regexp"
+	"sort"
 
 	"github.com/deis/controller-sdk-go/api"
 	"github.com/deis/controller-sdk-go/config"
@@ -24,23 +25,14 @@ func (d *DeisCmd) AnnotationList(appID string, format string) error {
 	}
 	var configOutput = new(bytes.Buffer)
 
-	/*** type casting to map[string]interface{}
-	 * the sortKeys function takes a map[string]interface{}, but config.Annotations
-	 * is of type map[string]Annotations. Because of that type difference, the function
-	 * cannot take `config.Annotation` directly. So we have two main options, either
-	 * replicate the sortKeys function changing only its type signature, or copy
-	 * the map into another one with the correct type. This approach was selected
-	 * because this map will likely have 2 or 3 elements, so copying this way
-	 * should not impact negatively on performance and will keep the code cleaner.
-	 */
-	interfacedStuff := make(map[string]interface{})
-	for k, v := range config.Annotations {
-		interfacedStuff[k] = v
+	appTypes := make([]string, 0, len(config.Annotations))
+	for k := range config.Annotations {
+		appTypes = append(appTypes, k)
 	}
 
-	sortedTypes := sortKeys(interfacedStuff)
+	sort.Strings(appTypes)
 
-	for _, appType := range sortedTypes {
+	for _, appType := range appTypes {
 		annotations := config.Annotations[appType]
 		keys := sortKeys(annotations)
 		switch format {

--- a/cmd/annotation_test.go
+++ b/cmd/annotation_test.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/deis/controller-sdk-go/api"
+	"github.com/deis/workflow-cli/pkg/testutil"
+)
+
+func TestAnnotationList(t *testing.T) {
+	t.Parallel()
+	cf, server, err := testutil.NewTestServerAndClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	server.Mux.HandleFunc("/v2/apps/foo/config/", func(w http.ResponseWriter, r *http.Request) {
+		testutil.SetHeaders(w)
+		fmt.Fprintf(w, `{
+    "owner": "jkirk",
+    "app": "foo",
+    "annotations": {
+        "cmd": {
+            "k8s.annotation": "testing",
+            "k8s.another/annotation": "anotherone",
+            "k8s.json/annotation": "{\"hello\":\"world\"}"
+        }
+    },
+    "values": {},
+    "memory": {},
+    "cpu": {},
+    "tags": {},
+    "registry": {},
+    "created": "2014-01-01T00:00:00UTC",
+    "updated": "2014-01-01T00:00:00UTC",
+    "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+}`)
+	})
+
+	var b bytes.Buffer
+	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
+
+	err = cmdr.AnnotationList("foo", "")
+	assert.NoErr(t, err)
+
+	assert.Equal(t, b.String(), `=== cmd Annotations
+k8s.annotation              testing
+k8s.another/annotation      anotherone
+k8s.json/annotation         {"hello":"world"}
+`, "output")
+	b.Reset()
+
+	err = cmdr.AnnotationList("foo", "oneline")
+	assert.NoErr(t, err)
+	assert.Equal(t, b.String(),"cmd: k8s.annotation=testing k8s.another/annotation=anotherone k8s.json/annotation={\"hello\":\"world\"}\n", "output")
+
+	b.Reset()
+
+	err = cmdr.AnnotationList("foo", "diff")
+	assert.NoErr(t, err)
+	assert.Equal(t, b.String(),`cmd:
+    k8s.annotation=testing
+    k8s.another/annotation=anotherone
+    k8s.json/annotation={"hello":"world"}
+`, "output")
+}
+
+func TestAnnotationsSet(t *testing.T) {
+	t.Parallel()
+	cf, server, err := testutil.NewTestServerAndClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	server.Mux.HandleFunc("/v2/apps/foo/config/", func(w http.ResponseWriter, r *http.Request) {
+		testutil.SetHeaders(w)
+		if r.Method == "POST" {
+			testutil.AssertBody(t, api.Config{
+				Annotations: map[string]api.Annotation{
+					"cmd": map[string]interface{} {
+						"k8s.annotation": "testing",
+					},
+				},
+			}, r)
+		}
+
+		fmt.Fprintf(w, `{
+	"owner": "jkirk",
+	"app": "foo",
+    "annotations": {
+        "cmd": {
+            "k8s.annotation": "testing"
+        }
+    }
+}`)
+	})
+
+	var b bytes.Buffer
+	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
+
+	err = cmdr.AnnotationSet("foo", "cmd", []string{"k8s.annotation=testing"})
+	assert.NoErr(t, err)
+
+	assert.Equal(t, testutil.StripProgress(b.String()), `Creating Annotations... done
+
+=== cmd Annotations
+k8s.annotation      testing
+`, "output")
+}
+
+func TestAnnotationUnset(t *testing.T) {
+	t.Parallel()
+	cf, server, err := testutil.NewTestServerAndClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	server.Mux.HandleFunc("/v2/apps/foo/config/", func(w http.ResponseWriter, r *http.Request) {
+		testutil.SetHeaders(w)
+		if r.Method == "POST" {
+			testutil.AssertBody(t, api.Config{
+				Annotations: map[string]api.Annotation{
+					"cmd": map[string]interface{}{
+						"k8s.annotation": nil,
+					},
+				},
+			}, r)
+		}
+
+		fmt.Fprintf(w, `{
+	"owner": "jkirk",
+	"app": "foo",
+    "annotations": {
+        "cmd": {
+            "k8s.another/annotation": "another"
+        }
+    }
+}`)
+	})
+
+	var b bytes.Buffer
+	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
+
+	err = cmdr.AnnotationUnset("foo", "cmd", []string{"k8s.annotation"})
+	assert.NoErr(t, err)
+
+	assert.Equal(t, testutil.StripProgress(b.String()), `Removing Annotations... done
+
+=== cmd Annotations
+k8s.another/annotation      another
+`, "output")
+}
+

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -10,6 +10,9 @@ import (
 
 // Commander is interface definition for running commands
 type Commander interface {
+	AnnotationList(string, string) error
+	AnnotationSet(string, string, []string) error
+	AnnotationUnset(string, string, []string) error
 	AppCreate(string, string, string, bool) error
 	AppsList(int) error
 	AppInfo(string) error

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -84,13 +84,18 @@ func (d *DeisCmd) ConfigSet(appID string, configVars []string) error {
 		configMap["SSH_KEY"] = base64.StdEncoding.EncodeToString([]byte(sshKey))
 	}
 
-	// NOTE(bacongobbler): check if the user is using the old way to set healthchecks. If so,
-	// send them a deprecation notice.
+	// NOTE(bacongobbler): check if the user is using the old way to set healthchecks or
+	// annotations. If so, send them a deprecation notice.
 	for key := range configMap {
 		if strings.Contains(key, "HEALTHCHECK_") {
 			d.Println(`Hey there! We've noticed that you're using 'deis config:set HEALTHCHECK_URL'
 to set up healthchecks. This functionality has been deprecated. In the future, please use
 'deis healthchecks' to set up application health checks. Thanks!`)
+		}
+		if strings.Contains(key, "KUBERNETES_PODS_ANNOTATIONS") {
+			d.Println(`Hey there! We've noticed that you're using 'deis config:set KUBERNETES_PODS_ANNOTATIONS'
+to set up annotations. This functionality has been deprecated. Please prefer setting annotations using the
+'deis annotations' command. Thanks!`)
 		}
 	}
 

--- a/deis.go
+++ b/deis.go
@@ -47,6 +47,7 @@ Auth commands, use 'deis help auth' to learn more::
 
 Subcommands, use 'deis help [subcommand]' to learn more::
 
+  annotation    manage annotations that are used to label the pods
   apps          manage applications used to provide services
   autoscale     manage autoscale for applications
   builds        manage builds created using 'git push'
@@ -106,6 +107,8 @@ Use 'git push deis master' to deploy to an application.
 	// Dispatch the command, passing the argv through so subcommands can
 	// re-parse it according to their usage strings.
 	switch command {
+	case "annotation":
+		err = parser.Annotation(argv, &cmdr)
 	case "apps":
 		err = parser.Apps(argv, &cmdr)
 	case "auth":

--- a/parser/annotations.go
+++ b/parser/annotations.go
@@ -1,0 +1,142 @@
+package parser
+
+import (
+	"github.com/deis/workflow-cli/cmd"
+	docopt "github.com/docopt/docopt-go"
+)
+
+// Annnotations routes annotation commands to their specific function.
+func Annotation(argv []string, cmdr cmd.Commander) error {
+	usage := `
+Valid commands for annotations:
+
+annotation:list        list annotations for an app
+annotation:set         set annotations for an app
+annotation:unset       unset annotations for an app
+
+Use 'deis help [command]' to learn more.
+`
+
+	switch argv[0] {
+	case "annotation:list":
+		return annotationList(argv, cmdr)
+	case "annotation:set":
+		return annotationSet(argv, cmdr)
+	case "annotation:unset":
+		return annotationUnset(argv, cmdr)
+	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "annotation" {
+			argv[0] = "annotation:list"
+			return annotationList(argv, cmdr)
+		}
+
+		PrintUsage(cmdr)
+		return nil
+	}
+}
+
+func annotationList(argv []string, cmdr cmd.Commander) error {
+	usage := `
+Lists annotations for the pods of an application.
+
+Usage: deis annotation:list [options]
+
+Options:
+  --oneline
+    print output on one line.
+  -a --app=<app>
+    the uniquely identifiable name of the application.
+`
+
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
+		return err
+	}
+	app := safeGetValue(args, "--app")
+	oneline := args["--oneline"].(bool)
+
+	format := ""
+	if oneline {
+		format = "oneline"
+	}
+
+	return cmdr.AnnotationList(app, format)
+}
+
+func annotationSet(argv []string, cmdr cmd.Commander) error {
+	usage := `
+Sets annotations for the pods of an application.
+
+Usage: deis annotation:set --type=<app_type> <var>=<value> [<var>=<value>...] [options]
+
+Arguments:
+  <app_type>
+    the process type as defined in your Procfile, such as 'web' or 'worker'.
+    Note that Dockerfile apps have a default 'cmd' process type.
+  <var>
+    the uniquely identifiable name for the annotation.
+  <value>
+    the value of said annotation.
+
+Options:
+  -a --app=<app>
+    the uniquely identifiable name for the application.
+  -t --type=<app_type>
+	the process type to be affected by these annotations.
+`
+
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
+		return err
+	}
+
+	app := safeGetValue(args, "--app")
+
+	appType := safeGetValue(args, "--type")
+	if appType == "" {
+		appType = "cmd"
+	}
+
+	return cmdr.AnnotationSet(app, appType, args["<var>=<value>"].([]string))
+}
+
+func annotationUnset(argv []string, cmdr cmd.Commander) error {
+	usage := `
+Unsets an annotation for the pods of an application.
+
+Usage: deis annotation:unset --type=<app_type> <key>... [options]
+
+Arguments:
+  <app_type>
+    the process type as defined in your Procfile, such as 'web' or 'worker'.
+    Note that Dockerfile apps have a default 'cmd' process type.
+  <key>
+    the annotation to remove from the application's pod.
+
+Options:
+  -a --app=<app>
+    the uniquely identifiable name for the application.
+  -t --type=<app_type>
+	the process type to be affected by these annotations.
+`
+
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
+		return err
+	}
+	app := safeGetValue(args, "--app")
+
+	appType := safeGetValue(args, "--type")
+	if appType == "" {
+		appType = "cmd"
+	}
+
+	return cmdr.AnnotationUnset(app, appType, args["<key>"].([]string))
+}

--- a/parser/annotations.go
+++ b/parser/annotations.go
@@ -8,7 +8,7 @@ import (
 // Annnotations routes annotation commands to their specific function.
 func Annotation(argv []string, cmdr cmd.Commander) error {
 	usage := `
-Valid commands for annotations:
+Valid commands for annotation:
 
 annotation:list        list annotations for an app
 annotation:set         set annotations for an app

--- a/parser/annotations_test.go
+++ b/parser/annotations_test.go
@@ -1,0 +1,74 @@
+package parser
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/deis/workflow-cli/pkg/testutil"
+)
+
+// Create fake implementations of each method that return the argument
+// we expect to have called the function (as an error to satisfy the interface).
+
+func (d FakeDeisCmd) AnnotationList(string, string) error {
+	return errors.New("annotation:list")
+}
+
+func (d FakeDeisCmd) AnnotationSet(string, string, []string) error {
+	return errors.New("annotation:set")
+}
+
+func (d FakeDeisCmd) AnnotationUnset(string, string, []string) error {
+	return errors.New("annotation:unset")
+}
+
+func TestAnnotation(t *testing.T) {
+	t.Parallel()
+
+	cf, server, err := testutil.NewTestServerAndClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	var b bytes.Buffer
+	cmdr := FakeDeisCmd{WOut: &b, ConfigFile: cf}
+
+	// cases defines the arguments and expected return of the call.
+	// if expected is "", it defaults to args[0].
+	cases := []struct {
+		args     []string
+		expected string
+	}{
+		{
+			args:     []string{"annotation:list"},
+			expected: "",
+		},
+		{
+			args:     []string{"annotation:set", "--type=cmd", "var=value"},
+			expected: "",
+		},
+		{
+			args:     []string{"annotation:unset", "--type=cmd", "var"},
+			expected: "",
+		},
+		{
+			args:     []string{"annotation"},
+			expected: "annotation:list",
+		},
+	}
+
+	// For each case, check that calling the route with the arguments
+	// returns the expected error, which is args[0] if not provided.
+	for _, c := range cases {
+		var expected string
+		if c.expected == "" {
+			expected = c.args[0]
+		} else {
+			expected = c.expected
+		}
+		err = Annotation(c.args, cmdr)
+		assert.Err(t, errors.New(expected), err)
+	}
+}


### PR DESCRIPTION
This Pull Request adds the annotations functionality to the deis cli, as discussed in topfreegames/controller#4.

the command `deis annotation` was added
```
Valid commands for annotation:

annotation:list        list annotations for an app
annotation:set         set annotations for an app
annotation:unset       unset annotations for an app
```

Annotations added with this command will take precedence over any added using the `config` introduced in topfreegames/controller#4

Related Pull Requests:
- topfreegames/controller-sdk-go#3
- topfreegames/controller#5
